### PR TITLE
style: remove redundant font-weight class from BookCard

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -73,7 +73,7 @@ const BookCard: React.FC<BookCardProps> = ({ book }) => {
 								</span>
 							)} */}
 						</div>
-						<div className='flex flex-wrap gap-8 font-medium text-bones-blue dark:text-bones-lightsteelblue font-semibold'>
+						<div className='flex flex-wrap gap-8 text-bones-blue dark:text-bones-lightsteelblue font-semibold'>
 							{links.map((link, index) => (
 								<a
 									key={index}


### PR DESCRIPTION
Eliminate the unnecessary 'font-medium' class from the BookCard 
component to streamline the styling. This change enhances code 
readability and maintains the intended design without affecting 
the visual output.