### PR TITLE
fix(Books): use book.slug instead of book.title for routing

### DIFF
--- a/src/components/Books.tsx
+++ b/src/components/Books.tsx
@@ -170,7 +170,7 @@ const Books: React.FC<{ className?: string }> = ({ className = '' }) => {
 				isOpen={isModalOpen}
 				onClose={handleCloseModal}
 				onBookChange={(book: Book) => {
-					const bookSlug = book.title
+					const bookSlug = book.slug
 						.toLowerCase()
 						.replace(/\s+/g, '-');
 					router.push(`/?book=${bookSlug}`);


### PR DESCRIPTION
Update book change handler to use the book's slug property instead
of the title when generating the URL slug. This ensures consistent
and accurate routing based on the unique slug rather than the title,
which may contain spaces or special characters.