### PR TITLE
feat(seo): enhance metadata and social sharing tags

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,10 +18,55 @@ const dmSerifDisplay = DM_Serif_Display({
 	display: 'swap',
 });
 
-// Metadata for the site
+const siteUrl = 'https://read.renderg.host';
+const siteTitle = 'Read | Book recommendations by Barry Prendergast.';
+const siteDescription =
+	'24 books to re-shape how you think about great design.';
+const defaultImage = `${siteUrl}/og-default.jpg`; // Add this image to public/og-default.jpg
+
 export const metadata: Metadata = {
-	title: 'Read | Book recommendations by Barry Prendergast.',
-	description: '24 books to re-shape how you think about great design.',
+	title: siteTitle,
+	description: siteDescription,
+	metadataBase: new URL(siteUrl),
+	alternates: {
+		canonical: siteUrl,
+	},
+	openGraph: {
+		type: 'website',
+		url: siteUrl,
+		title: siteTitle,
+		description: siteDescription,
+		images: [
+			{
+				url: defaultImage,
+				width: 1200,
+				height: 630,
+				alt: 'Book recommendations by Barry Prendergast',
+			},
+		],
+		siteName: 'Read',
+	},
+	twitter: {
+		card: 'summary_large_image',
+		title: siteTitle,
+		description: siteDescription,
+		images: [defaultImage],
+	},
+	keywords: [
+		'book recommendations',
+		'design books',
+		'Barry Prendergast',
+		'creative thinking',
+		'best books',
+	],
+	robots: {
+		index: true,
+		follow: true,
+		googleBot: {
+			index: true,
+			follow: true,
+		},
+	},
 };
 
 // Root layout component with TypeScript typing

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -6,6 +6,7 @@ import { Book } from '@/types/Book';
 import BookDetail from './BookDetail';
 import { books } from '@/constants/books';
 import { X } from 'lucide-react';
+import Head from 'next/head';
 
 interface ModalProps {
 	book: Book | null;
@@ -88,10 +89,53 @@ const Modal: React.FC<ModalProps> = ({
 	}, [isOpen]);
 
 	if (!book) return null;
+	const siteUrl = 'https://read.renderg.host';
+	const pageUrl = `${siteUrl}/?book=${encodeURIComponent(book.slug)}`;
+	const imageUrl = book.coverImage.startsWith('http')
+		? book.coverImage
+		: `${siteUrl}${book.coverImage}`;
+	const authors = book.authors.map(a => a.name).join(', ');
 
 	return (
-		<AnimatePresence>
-			{isOpen && (
+		<>
+			{book && (
+				<Head>
+					<title>{`${book.title} by ${authors} | Read`}</title>
+					<meta
+						name='description'
+						content={book.metadata.blurb || book.personalComment}
+					/>
+					<link rel='canonical' href={pageUrl} />
+
+					{/* Open Graph */}
+					<meta property='og:type' content='book' />
+					<meta property='og:url' content={pageUrl} />
+					<meta
+						property='og:title'
+						content={`${book.title} by ${authors}`}
+					/>
+					<meta
+						property='og:description'
+						content={book.metadata.blurb || book.personalComment}
+					/>
+					<meta property='og:image' content={imageUrl} />
+					<meta property='og:site_name' content='Read' />
+
+					{/* Twitter Card */}
+					<meta name='twitter:card' content='summary_large_image' />
+					<meta
+						name='twitter:title'
+						content={`${book.title} by ${authors}`}
+					/>
+					<meta
+						name='twitter:description'
+						content={book.metadata.blurb || book.personalComment}
+					/>
+					<meta name='twitter:image' content={imageUrl} />
+				</Head>
+			)}
+			<AnimatePresence>
+				{isOpen && book && (
 				<motion.div
 					initial={{ opacity: 0 }}
 					animate={{ opacity: 1 }}
@@ -123,7 +167,8 @@ const Modal: React.FC<ModalProps> = ({
 									className='text-3xl font-black text-bones-black dark:text-bones-linen'>
 									{book.title} by{' '}
 									{book.authors.map((author, index) => (
-										<React.Fragment key={index}>
+										<React.Fragment
+											key={`${book.slug}-${author.name}`}>
 											{author.link ? (
 												<a
 													href={author.link}
@@ -193,7 +238,8 @@ const Modal: React.FC<ModalProps> = ({
 					</motion.div>
 				</motion.div>
 			)}
-		</AnimatePresence>
+			</AnimatePresence>
+		</>
 	);
 };
 


### PR DESCRIPTION
Refactor site metadata to use centralized constants and add full
Open Graph and Twitter card support for the site. Improve Modal
component by dynamically injecting book-specific metadata (title,
description, canonical URL, and images) into the document head when
a book is open. This enables better SEO and richer link previews
for individual book pages.