### PR TITLE
fix(books): correct metadata for Indistractable book entry

### DIFF
--- a/src/constants/books.ts
+++ b/src/constants/books.ts
@@ -371,9 +371,9 @@ export const books: Book[] = [
 		],
 		coverImage: '/books/eyal.jpg',
 		metadata: {
-			shortname: 'Psychology',
+			shortname: 'Indistractable',
 			blurb: 'A guide to controlling your attention and choosing your life, teaching how to become indistractable in an increasingly distracting world.',
-			genre: 'Self-Help',
+			genre: 'Psychology',
 			pageCount: 304,
 			publisher: 'Portfolio',
 			publishYear: 2019,


### PR DESCRIPTION
Update the shortname to "Indistractable" and change the genre to
"Psychology" for the book entry. This ensures accurate categorization
and improves data consistency for the book "Indistractable."